### PR TITLE
HP footer responsiveness added

### DIFF
--- a/POLMED/src/styles/layout/_footer.scss
+++ b/POLMED/src/styles/layout/_footer.scss
@@ -2,7 +2,7 @@
   @include flex(column);
   gap: 0.7em;
   background: $color-gradient;
-  padding: 1.5em 0;
+  padding: 1.5em;
   width: 100%;
 }
 
@@ -48,4 +48,16 @@
   font-size: 0.875em;
   line-height: 1em;
   color: $white;
+}
+
+@media (max-width: 768px) {
+  .hp-footer-upper {
+    grid-template-columns: 1fr;
+    gap: 1em;
+  }
+
+  .hp-footer-ul {
+    flex-direction: column;
+    gap: 0.5em;
+  }
 }


### PR DESCRIPTION
Dodałem responsywność stopki na stronie głównej, dla ułatwienia i niekomplikowania niepotrzebnie sprawy trochę różni się od projektu. 
![image](https://user-images.githubusercontent.com/33033063/206419331-7394f978-d93e-4ecf-bf29-36225388cf27.png)

Dodatkowo zwiększyłem padding stopki, żeby napisy nie dotykały krawędzi przeglądarki.
![image](https://user-images.githubusercontent.com/33033063/206420202-c9f7a0b5-7b26-42ff-ba0b-a2a8777f37ec.png)

Stopka dla pozostałych stron była już responsywna.
